### PR TITLE
Make the development database persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,6 @@ The database uses volumes from a persistent data-only container called dbdata, s
 
 However, this does mean that you will need to manually create and populate the database once the container is running, with the following commands:
 
-    docker exec -ti dsauth_web_1 "bundle exec rake db:create"
-    docker exec -ti dsauth_web_1 "bundle exec rake db:migrate"
-    docker exec -ti dsauth_web_1 "bundle exec rake db:seed"
+    docker-compose run web bundle exec rake db:create
+    docker-compose run web bundle exec rake db:migrate
+    docker-compose run web bundle exec rake db:seed

--- a/README.md
+++ b/README.md
@@ -138,9 +138,7 @@ To get the application running locally, you need to:
 
  * #### Create and migrate the database; run seeds
 
- 		bundle exec rake db:create
- 		bundle exec rake db:migrate
-
+    ```bundle exec rake db:create db:migrate; bundle exec rake db:seed```
 
  * #### Start the server
  		cd ds-auth && bundle exec rails server
@@ -172,3 +170,10 @@ A [Makefile](Makefile) is provided to build the app as a docker image.
 
 Note: docker compose will use the most recent image built by ```make development_container```. It will not build the container itself.
 
+The database uses volumes from a persistent data-only container called dbdata, so that data you modify during a session will not be lost when you restart the web container.
+
+However, this does mean that you will need to manually create and populate the database once the container is running, with the following commands:
+
+    docker exec -ti dsauth_web_1 "bundle exec rake db:create"
+    docker exec -ti dsauth_web_1 "bundle exec rake db:migrate"
+    docker exec -ti dsauth_web_1 "bundle exec rake db:seed"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,19 @@ web:
     - "3000:3000"
   volumes:
     - .:/usr/src/app
-  command: bash -c "bundle exec rake db:reset && bundle exec rake users:create_webops name='Webops' email=webops@example.com password='password' && bundle exec rails s -b 0.0.0.0"
+  command: bash -c "bundle exec rails s -b 0.0.0.0"
+
+
+dbdata:
+  image: cogniteev/echo
+  command: echo 'Persistent data container for PostgreSQL'
+  volumes:
+    - /var/lib/postgresql/data
 
 db:
   image: postgres
   environment:
     DS_AUTH_DATABASE_PASSWORD: password
     DS_AUTH_DATABASE_USERNAME: ds_auth
+  volumes_from:
+    - dbdata

--- a/docker/Dockerfile-development
+++ b/docker/Dockerfile-development
@@ -32,5 +32,9 @@ WORKDIR /usr/src/app
 # We don't run /usr/local/bin/clean-up-docker-container here, since in development mode
 # users may want to quickly run 'apt-get install packagename'.
 
+RUN bundle exec rake db:create db:schema:load db:migrate
+#  docker exec -ti ${DOCKER_IMAGE} "bundle exec rake db:seed && bundle exec rake users:create_webops name='Webops' email=webops@example.com password='password'""
+
+
 # Open rails console by default
 CMD ["bin/bundle", "exec", "rails", "console"]


### PR DESCRIPTION
Introduced a data-only container to allow the postgres data volume to persist across container restarts.
Also removed the explicit "db:reset" call every time the web container starts.