### PR TITLE
Allow specs to be run with rspec executable

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require "rspec/rails"
 require "shoulda-matchers"
 require "capybara/poltergeist"
 require "devise"
+require "database_cleaner"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }
 


### PR DESCRIPTION
This fixes an issue with the environment set up when trying to run individual tests via rspec, rather than test suites via rake

It was not auto-loading the DatabaseCleaner dependency, causing a message 'undefined constant DatabaseCleaner' after the test.

Fixed by explicitly requiring it in rails_helper.rb
